### PR TITLE
Add clean and single-commit option to workflow

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -23,3 +23,4 @@ jobs:
           branch: gh-pages
           folder: docs
           clean: true
+          single-commit: true

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -22,3 +22,4 @@ jobs:
         with:
           branch: gh-pages
           folder: docs
+          clean: true


### PR DESCRIPTION
This pull request changes workflow configurations.

- The `clean` option works by deleting files from [the deploy branch](https://github.com/sglkc/ohayou/tree/gh-pages) that doesn't exist in the latest build.
- The `single-commit` option omits the full history and ensures only one commit exists in [the deploy branch](https://github.com/sglkc/ohayou/tree/gh-pages).